### PR TITLE
🧹 [code health] Type 'config' parameter in AudioEngine._replaceNoiseLayer

### DIFF
--- a/web/src/engine/audio.ts
+++ b/web/src/engine/audio.ts
@@ -10,6 +10,13 @@
 
 export type StingerName = 'click' | 'heartbeat' | 'whisper' | 'scream';
 
+interface AmbientConfig {
+  droneFreqs: number[];
+  droneGain: number;
+  noiseGain: number;
+  filterFreq: number;
+}
+
 const STINGER_COOLDOWNS: Record<string, number> = {
   click: 500,
   heartbeat: 3000,
@@ -17,7 +24,7 @@ const STINGER_COOLDOWNS: Record<string, number> = {
   scream: 15000,
 };
 
-const AMBIENT_CONFIGS = [
+const AMBIENT_CONFIGS: AmbientConfig[] = [
   // 0 DORMANT
   { droneFreqs: [27.5, 41.2],                       droneGain: 0.015, noiseGain: 0.008, filterFreq: 80  },
   // 1 AWAKENING
@@ -311,7 +318,7 @@ export class AudioEngine {
     this.noiseGainNode = null;
   }
 
-  private _replaceNoiseLayer(config: any, now: number, rampTime: number): void {
+  private _replaceNoiseLayer(config: AmbientConfig, now: number, rampTime: number): void {
     if (!this.ctx || !this.masterGain) return;
 
     if (!this.noiseBuffer || this.noiseBuffer.sampleRate !== this.ctx.sampleRate) {


### PR DESCRIPTION
This PR improves the maintainability and readability of the `AudioEngine` by replacing an `any` type with a structured interface.

### 🎯 What
The `config` parameter in `AudioEngine._replaceNoiseLayer` was typed as `any`. It now uses a dedicated `AmbientConfig` interface.

### 💡 Why
Using `any` hides the structure of the configuration object and prevents TypeScript from catching potential errors when accessing its properties (`filterFreq`, `noiseGain`). Defining an interface makes the code more self-documenting and safe.

### ✅ Verification
- Verified the code structure using `read_file`.
- Ran existing audio engine tests from the root directory using `bun test` (with minor compatibility tweaks) to ensure no regressions in the core audio logic.
- A full build and typecheck were attempted but skipped due to environment-specific limitations (no `tsc` in path, no network access for `npx`).

### ✨ Result
The `AudioEngine` configuration is now strictly typed, providing better IDE support and compile-time safety.

---
*PR created automatically by Jules for task [17087763852485919791](https://jules.google.com/task/17087763852485919791) started by @sistemascancunjefe-ai*